### PR TITLE
Adding documentation of mass matrix

### DIFF
--- a/docs/docs-api/MassMatrix/examples/MassMatrix_test_3.F90
+++ b/docs/docs-api/MassMatrix/examples/MassMatrix_test_3.F90
@@ -1,133 +1,59 @@
----
-title: MassMatrix example 3 
-author: Vikas Sharma, Ph.D.
-date: 20 Nov 2021
-update: 20 Nov 2021 
-tags:
-    - ReferenceLine
-    - ReferenceLine/Initiate
-    - QuadraturePoint/Initiate
-    - ElemshapeData/Initiate
-    - MassMatrix
----
-
-# MassMatrix example 3
-
-!!! note ""
-    This example shows how to USE the SUBROUTINE called `MassMatrix` to create a mass matrix in space domain.
-    
-Here, we want to DO the following. 
-
-$$
-\int_{\Omega } N^{I}\rho N^{J}d\Omega
-$$
-
-!!! warning ""
-    `rho` can be a constant, or a FUNCTION of spatial coordinates, or some nonlinear FUNCTION.
-    
-In this example, following mass matrix is formed for [[ReferenceLine_]] element,  [[QuadraturePoint_]] are `GaussLegendre`.
-
-$$
-\int_{\Omega } N^{I} N^{J}d\Omega
-$$
-
-This TYPE of mass matrix is useful when $rho$ is a constant.
-
-## Modules and classes
-
-## Usage
-
-```fortran
 PROGRAM main
-    USE easifemBase
-    IMPLICIT NONE
-    TYPE(Elemshapedata_) :: test, elemsdForsimplex, trial
-    TYPE(Quadraturepoint_) :: quad
-    TYPE(Referenceline_) :: simplexElem, refElemFortest, refElemFortrial
-    REAL(DFP), ALLOCATABLE :: mat(:, :), XiJ(:, :)
-    INTEGER( I4B ), PARAMETER :: orderFortest = 1, orderForTrial = 2
-```
+USE easifemBase
+IMPLICIT NONE
+TYPE(Elemshapedata_) :: test, elemsdForsimplex, trial
+TYPE(Quadraturepoint_) :: quad
+TYPE(Referenceline_) :: simplexElem, refElemFortest, refElemFortrial
+REAL(DFP), ALLOCATABLE :: mat(:, :), XiJ(:, :)
+INTEGER(I4B), PARAMETER :: orderFortest = 1, orderForTrial = 2
 
-!!! note ""
-    Let us now create the physical coordinate of the line element.
+! Let us now create the physical coordinate of the line element.
 
-```fortran
-    XiJ = RESHAPE([-1, 1], [1, 2])
-```
+XiJ = RESHAPE([-1, 1], [1, 2])
 
-!!! note ""
-    Now  we create an instance of [[ReferenceLine_]].
+! Now  we create an instance of [[ReferenceLine_]].
 
-```fortran
-    simplexElem = referenceline(nsd=1)
+simplexElem = referenceline(nsd=1)
     CALL simplexElem%LagrangeElement(order=orderForTest, highOrderObj=refElemForTest)
     CALL simplexElem%LagrangeElement(order=orderForTrial, highOrderObj=refElemForTrial)
-```
 
-!!! note ""
-    Here, we create the quadrature points.
-
-```fortran
+! Here, we create the quadrature points.
     CALL initiate( obj=quad, refelem=simplexElem, order=orderForTest+orderForTrial, &
-        & quadratureType='GaussLegendre' )
-```
+              quadratureType='GaussLegendre')
 
-!!! note ""
-    Initiate an instance of [[ElemshapeData_]]. You can learn more about it from [[ElemshapeData_test]].
+! Initiate an instance of [[ElemshapeData_]]. You can learn more about it from [[ElemshapeData_test]].
 
-```fortran
-    CALL initiate(obj=elemsdForsimplex, &
-        & quad=quad, &
-        & refelem=simplexElem, &
-        & ContinuityType=typeH1, &
-        & InterpolType=typeLagrangeInterpolation)
-```
+CALL initiate(obj=elemsdForsimplex, &
+              quad=quad, &
+              refelem=simplexElem, &
+              ContinuityType=typeH1, &
+              InterpolType=typeLagrangeInterpolation)
 
-!!! note ""
-    Initiate an instance of [[ElemeshapeData_]] for test function.
-    
-```fortran
-    CALL initiate(obj=test, &
-        & quad=quad, &
-        & refelem=refElemForTest, &
-        & ContinuityType=typeH1, &
-        & InterpolType=typeLagrangeInterpolation)
-    CALL Set(obj=test, val=xij, N=elemsdForSimplex%N, &
-        & dNdXi=elemsdForSimplex%dNdXi)
-```
+! Initiate an instance of [[ElemeshapeData_]] for test function.
 
-!!! note ""
-    Initiate an instance of [[ElemeshapeData_]] for trial function.
-    
-```fortran
-    CALL initiate(obj=trial, &
-        & quad=quad, &
-        & refelem=refElemForTrial, &
-        & ContinuityType=typeH1, &
-        & InterpolType=typeLagrangeInterpolation)
-    CALL Set(obj=trial, val=xij, N=elemsdForSimplex%N, &
-        & dNdXi=elemsdForSimplex%dNdXi)
-```
+CALL initiate(obj=test, &
+              quad=quad, &
+              refelem=refElemForTest, &
+              ContinuityType=typeH1, &
+              InterpolType=typeLagrangeInterpolation)
 
-!!! note ""
-    Let us now create the mass matrix.
+CALL Set(obj=test, val=xij, N=elemsdForSimplex%N, &
+         dNdXi=elemsdForSimplex%dNdXi)
 
-```fortran
-    mat=MassMatrix(test=test, trial=trial)
-    CALL Display(mat, "mat:")
-```
+! Initiate an instance of [[ElemeshapeData_]] for trial function.
 
-??? example "Results"
+CALL initiate(obj=trial, &
+              quad=quad, &
+              refelem=refElemForTrial, &
+              ContinuityType=typeH1, &
+              InterpolType=typeLagrangeInterpolation)
 
-    ```bash
-                mat:          
-    -------------------------
-    0.33333  0.00000  0.66667
-    0.00000  0.33333  0.66667
-    ```
+CALL Set(obj=trial, val=xij, N=elemsdForSimplex%N, &
+         dNdXi=elemsdForSimplex%dNdXi)
 
-!!! settings "Cleanup"
+! Let us now create the mass matrix.
 
-```fortran
+mat = MassMatrix(test=test, trial=trial)
+CALL Display(mat, "mat:")
+
 END PROGRAM main
-```

--- a/docs/docs-api/MassMatrix/examples/MassMatrix_test_3.md
+++ b/docs/docs-api/MassMatrix/examples/MassMatrix_test_3.md
@@ -1,31 +1,14 @@
----
-title: MassMatrix example 3 
-author: Vikas Sharma, Ph.D.
-date: 20 Nov 2021
-update: 20 Nov 2021 
-tags:
-    - ReferenceLine
-    - ReferenceLine/Initiate
-    - QuadraturePoint/Initiate
-    - ElemshapeData/Initiate
-    - MassMatrix
----
+This example shows how to USE the SUBROUTINE called `MassMatrix` to create a mass matrix in space domain.
 
-# MassMatrix example 3
-
-!!! note ""
-    This example shows how to USE the SUBROUTINE called `MassMatrix` to create a mass matrix in space domain.
-    
 Here, we want to DO the following. 
 
 $$
 \int_{\Omega } N^{I}\rho N^{J}d\Omega
 $$
 
-!!! warning ""
-    `rho` can be a constant, or a FUNCTION of spatial coordinates, or some nonlinear FUNCTION.
-    
-In this example, following mass matrix is formed for [[ReferenceLine_]] element,  [[QuadraturePoint_]] are `GaussLegendre`.
+`rho` can be a constant, or a FUNCTION of spatial coordinates, or some nonlinear FUNCTION.
+
+In this example, following mass matrix is formed for ReferenceLine element, QuadraturePoint are `GaussLegendre`.
 
 $$
 \int_{\Omega } N^{I} N^{J}d\Omega
@@ -33,101 +16,3 @@ $$
 
 This TYPE of mass matrix is useful when $rho$ is a constant.
 
-## Modules and classes
-
-## Usage
-
-```fortran
-PROGRAM main
-    USE easifemBase
-    IMPLICIT NONE
-    TYPE(Elemshapedata_) :: test, elemsdForsimplex, trial
-    TYPE(Quadraturepoint_) :: quad
-    TYPE(Referenceline_) :: simplexElem, refElemFortest, refElemFortrial
-    REAL(DFP), ALLOCATABLE :: mat(:, :), XiJ(:, :)
-    INTEGER( I4B ), PARAMETER :: orderFortest = 1, orderForTrial = 2
-```
-
-!!! note ""
-    Let us now create the physical coordinate of the line element.
-
-```fortran
-    XiJ = RESHAPE([-1, 1], [1, 2])
-```
-
-!!! note ""
-    Now  we create an instance of [[ReferenceLine_]].
-
-```fortran
-    simplexElem = referenceline(nsd=1)
-    CALL simplexElem%LagrangeElement(order=orderForTest, highOrderObj=refElemForTest)
-    CALL simplexElem%LagrangeElement(order=orderForTrial, highOrderObj=refElemForTrial)
-```
-
-!!! note ""
-    Here, we create the quadrature points.
-
-```fortran
-    CALL initiate( obj=quad, refelem=simplexElem, order=orderForTest+orderForTrial, &
-        & quadratureType='GaussLegendre' )
-```
-
-!!! note ""
-    Initiate an instance of [[ElemshapeData_]]. You can learn more about it from [[ElemshapeData_test]].
-
-```fortran
-    CALL initiate(obj=elemsdForsimplex, &
-        & quad=quad, &
-        & refelem=simplexElem, &
-        & ContinuityType=typeH1, &
-        & InterpolType=typeLagrangeInterpolation)
-```
-
-!!! note ""
-    Initiate an instance of [[ElemeshapeData_]] for test function.
-    
-```fortran
-    CALL initiate(obj=test, &
-        & quad=quad, &
-        & refelem=refElemForTest, &
-        & ContinuityType=typeH1, &
-        & InterpolType=typeLagrangeInterpolation)
-    CALL Set(obj=test, val=xij, N=elemsdForSimplex%N, &
-        & dNdXi=elemsdForSimplex%dNdXi)
-```
-
-!!! note ""
-    Initiate an instance of [[ElemeshapeData_]] for trial function.
-    
-```fortran
-    CALL initiate(obj=trial, &
-        & quad=quad, &
-        & refelem=refElemForTrial, &
-        & ContinuityType=typeH1, &
-        & InterpolType=typeLagrangeInterpolation)
-    CALL Set(obj=trial, val=xij, N=elemsdForSimplex%N, &
-        & dNdXi=elemsdForSimplex%dNdXi)
-```
-
-!!! note ""
-    Let us now create the mass matrix.
-
-```fortran
-    mat=MassMatrix(test=test, trial=trial)
-    CALL Display(mat, "mat:")
-```
-
-??? example "Results"
-
-    ```bash
-                mat:          
-    -------------------------
-    0.33333  0.00000  0.66667
-    0.00000  0.33333  0.66667
-    ```
-
-!!! settings "Cleanup"
-
-```fortran
-END PROGRAM main
-```

--- a/docs/docs-api/MassMatrix/examples/MassMatrix_test_4.F90
+++ b/docs/docs-api/MassMatrix/examples/MassMatrix_test_4.F90
@@ -1,134 +1,58 @@
----
-title: MassMatrix example 4 
-author: Vikas Sharma, Ph.D.
-date: 20 Nov 2021
-update: 20 Nov 2021 
-tags:
-    - ReferenceLine
-    - ReferenceLine/Initiate
-    - QuadraturePoint/Initiate
-    - ElemshapeData/Initiate
-    - MassMatrix
----
-
-# MassMatrix example 4
-
-!!! note ""
-    This example shows how to USE the SUBROUTINE called `MassMatrix` to create a mass matrix in space domain.
-    
-Here, we want to DO the following. 
-
-$$
-\int_{\Omega } N^{I}\rho N^{J}d\Omega
-$$
-
-!!! warning ""
-    `rho` can be a constant, or a FUNCTION of spatial coordinates, or some nonlinear FUNCTION.
-    
-In this example, following mass matrix is formed for [[ReferenceLine_]] element,  [[QuadraturePoint_]] are `GaussLegendre`.
-
-$$
-\int_{\Omega } N^{I} N^{J}d\Omega
-$$
-
-This TYPE of mass matrix is useful when $rho$ is a constant.
-
-## Modules and classes
-
-## Usage
-
-```fortran
 PROGRAM main
-    USE easifemBase
-    IMPLICIT NONE
-    TYPE(Elemshapedata_) :: test, elemsdForsimplex, trial
-    TYPE(Quadraturepoint_) :: quad
-    TYPE(Referenceline_) :: simplexElem, refElemFortest, refElemFortrial
-    REAL(DFP), ALLOCATABLE :: mat(:, :), XiJ(:, :)
-    INTEGER( I4B ), PARAMETER :: orderFortest = 1, orderForTrial = 2
-```
+USE easifemBase
+IMPLICIT NONE
+TYPE(Elemshapedata_) :: test, elemsdForsimplex, trial
+TYPE(Quadraturepoint_) :: quad
+TYPE(Referenceline_) :: simplexElem, refElemFortest, refElemFortrial
+REAL(DFP), ALLOCATABLE :: mat(:, :), XiJ(:, :)
+INTEGER(I4B), PARAMETER :: orderFortest = 1, orderForTrial = 2
 
-!!! note ""
-    Let us now create the physical coordinate of the line element.
+! Let us now create the physical coordinate of the line element.
 
-```fortran
-    XiJ = RESHAPE([-1, 1], [1, 2])
-```
+XiJ = RESHAPE([-1, 1], [1, 2])
 
-!!! note ""
-    Now  we create an instance of [[ReferenceLine_]].
+! Now  we create an instance of [[ReferenceLine_]].
 
-```fortran
-    simplexElem = referenceline(nsd=1)
+simplexElem = referenceline(nsd=1)
     CALL simplexElem%LagrangeElement(order=orderForTest, highOrderObj=refElemForTest)
     CALL simplexElem%LagrangeElement(order=orderForTrial, highOrderObj=refElemForTrial)
-```
 
-!!! note ""
-    Here, we create the quadrature points.
+! Here, we create the quadrature points.
 
-```fortran
     CALL initiate( obj=quad, refelem=simplexElem, order=orderForTest+orderForTrial, &
-        & quadratureType='GaussLegendre' )
-```
+              quadratureType='GaussLegendre')
 
-!!! note ""
-    Initiate an instance of [[ElemshapeData_]]. You can learn more about it from [[ElemshapeData_test]].
+! Initiate an instance of [[ElemshapeData_]]. You can learn more about it from [[ElemshapeData_test]].
 
-```fortran
-    CALL initiate(obj=elemsdForsimplex, &
-        & quad=quad, &
-        & refelem=simplexElem, &
-        & ContinuityType=typeH1, &
-        & InterpolType=typeLagrangeInterpolation)
-```
+CALL initiate(obj=elemsdForsimplex, &
+    & quad=quad, &
+    & refelem=simplexElem, &
+    & ContinuityType=typeH1, &
+    & InterpolType=typeLagrangeInterpolation)
 
-!!! note ""
-    Initiate an instance of [[ElemeshapeData_]] for test function.
-    
-```fortran
-    CALL initiate(obj=test, &
-        & quad=quad, &
-        & refelem=refElemForTest, &
-        & ContinuityType=typeH1, &
-        & InterpolType=typeLagrangeInterpolation)
-    CALL Set(obj=test, val=xij, N=elemsdForSimplex%N, &
-        & dNdXi=elemsdForSimplex%dNdXi)
-```
+! Initiate an instance of [[ElemeshapeData_]] for test function.
 
-!!! note ""
-    Initiate an instance of [[ElemeshapeData_]] for trial function.
-    
-```fortran
-    CALL initiate(obj=trial, &
-        & quad=quad, &
-        & refelem=refElemForTrial, &
-        & ContinuityType=typeH1, &
-        & InterpolType=typeLagrangeInterpolation)
-    CALL Set(obj=trial, val=xij, N=elemsdForSimplex%N, &
-        & dNdXi=elemsdForSimplex%dNdXi)
-```
+CALL initiate(obj=test, &
+    & quad=quad, &
+    & refelem=refElemForTest, &
+    & ContinuityType=typeH1, &
+    & InterpolType=typeLagrangeInterpolation)
+CALL Set(obj=test, val=xij, N=elemsdForSimplex%N, &
+    & dNdXi=elemsdForSimplex%dNdXi)
 
-!!! note ""
-    Let us now create the mass matrix.
+! Initiate an instance of [[ElemeshapeData_]] for trial function.
 
-```fortran
-    mat=MassMatrix(test=trial, trial=test)
-    CALL Display(mat, "mat:")
-```
+CALL initiate(obj=trial, &
+    & quad=quad, &
+    & refelem=refElemForTrial, &
+    & ContinuityType=typeH1, &
+    & InterpolType=typeLagrangeInterpolation)
+CALL Set(obj=trial, val=xij, N=elemsdForSimplex%N, &
+    & dNdXi=elemsdForSimplex%dNdXi)
 
-??? example "Results"
+! Let us now create the mass matrix.
 
-    ```bash
-        mat:      
-    ----------------
-    0.33333  0.00000
-    0.00000  0.33333
-    0.66667  0.66667
-    ```
+mat = MassMatrix(test=trial, trial=test)
+CALL Display(mat, "mat:")
 
-!!! settings "Cleanup"
-
-```fortran
 END PROGRAM main
-```

--- a/docs/docs-api/MassMatrix/examples/MassMatrix_test_4.md
+++ b/docs/docs-api/MassMatrix/examples/MassMatrix_test_4.md
@@ -1,31 +1,14 @@
----
-title: MassMatrix example 4 
-author: Vikas Sharma, Ph.D.
-date: 20 Nov 2021
-update: 20 Nov 2021 
-tags:
-    - ReferenceLine
-    - ReferenceLine/Initiate
-    - QuadraturePoint/Initiate
-    - ElemshapeData/Initiate
-    - MassMatrix
----
+This example shows how to USE the SUBROUTINE called `MassMatrix` to create a mass matrix in space domain.
 
-# MassMatrix example 4
-
-!!! note ""
-    This example shows how to USE the SUBROUTINE called `MassMatrix` to create a mass matrix in space domain.
-    
 Here, we want to DO the following. 
 
 $$
 \int_{\Omega } N^{I}\rho N^{J}d\Omega
 $$
 
-!!! warning ""
-    `rho` can be a constant, or a FUNCTION of spatial coordinates, or some nonlinear FUNCTION.
-    
-In this example, following mass matrix is formed for [[ReferenceLine_]] element,  [[QuadraturePoint_]] are `GaussLegendre`.
+`rho` can be a constant, or a FUNCTION of spatial coordinates, or some nonlinear FUNCTION.
+
+In this example, following mass matrix is formed for ReferenceLine element,  QuadraturePoint are `GaussLegendre`.
 
 $$
 \int_{\Omega } N^{I} N^{J}d\Omega
@@ -33,102 +16,3 @@ $$
 
 This TYPE of mass matrix is useful when $rho$ is a constant.
 
-## Modules and classes
-
-## Usage
-
-```fortran
-PROGRAM main
-    USE easifemBase
-    IMPLICIT NONE
-    TYPE(Elemshapedata_) :: test, elemsdForsimplex, trial
-    TYPE(Quadraturepoint_) :: quad
-    TYPE(Referenceline_) :: simplexElem, refElemFortest, refElemFortrial
-    REAL(DFP), ALLOCATABLE :: mat(:, :), XiJ(:, :)
-    INTEGER( I4B ), PARAMETER :: orderFortest = 1, orderForTrial = 2
-```
-
-!!! note ""
-    Let us now create the physical coordinate of the line element.
-
-```fortran
-    XiJ = RESHAPE([-1, 1], [1, 2])
-```
-
-!!! note ""
-    Now  we create an instance of [[ReferenceLine_]].
-
-```fortran
-    simplexElem = referenceline(nsd=1)
-    CALL simplexElem%LagrangeElement(order=orderForTest, highOrderObj=refElemForTest)
-    CALL simplexElem%LagrangeElement(order=orderForTrial, highOrderObj=refElemForTrial)
-```
-
-!!! note ""
-    Here, we create the quadrature points.
-
-```fortran
-    CALL initiate( obj=quad, refelem=simplexElem, order=orderForTest+orderForTrial, &
-        & quadratureType='GaussLegendre' )
-```
-
-!!! note ""
-    Initiate an instance of [[ElemshapeData_]]. You can learn more about it from [[ElemshapeData_test]].
-
-```fortran
-    CALL initiate(obj=elemsdForsimplex, &
-        & quad=quad, &
-        & refelem=simplexElem, &
-        & ContinuityType=typeH1, &
-        & InterpolType=typeLagrangeInterpolation)
-```
-
-!!! note ""
-    Initiate an instance of [[ElemeshapeData_]] for test function.
-    
-```fortran
-    CALL initiate(obj=test, &
-        & quad=quad, &
-        & refelem=refElemForTest, &
-        & ContinuityType=typeH1, &
-        & InterpolType=typeLagrangeInterpolation)
-    CALL Set(obj=test, val=xij, N=elemsdForSimplex%N, &
-        & dNdXi=elemsdForSimplex%dNdXi)
-```
-
-!!! note ""
-    Initiate an instance of [[ElemeshapeData_]] for trial function.
-    
-```fortran
-    CALL initiate(obj=trial, &
-        & quad=quad, &
-        & refelem=refElemForTrial, &
-        & ContinuityType=typeH1, &
-        & InterpolType=typeLagrangeInterpolation)
-    CALL Set(obj=trial, val=xij, N=elemsdForSimplex%N, &
-        & dNdXi=elemsdForSimplex%dNdXi)
-```
-
-!!! note ""
-    Let us now create the mass matrix.
-
-```fortran
-    mat=MassMatrix(test=trial, trial=test)
-    CALL Display(mat, "mat:")
-```
-
-??? example "Results"
-
-    ```bash
-        mat:      
-    ----------------
-    0.33333  0.00000
-    0.00000  0.33333
-    0.66667  0.66667
-    ```
-
-!!! settings "Cleanup"
-
-```fortran
-END PROGRAM main
-```

--- a/docs/docs-api/MassMatrix/examples/_MassMatrix_test_2.F90
+++ b/docs/docs-api/MassMatrix/examples/_MassMatrix_test_2.F90
@@ -1,120 +1,44 @@
----
-title: MassMatrix example 2
-author: Vikas Sharma, Ph.D.
-date: 20 Nov 2021
-update: 20 Nov 2021 
-tags:
-    - ReferenceLine
-    - ReferenceLine/Initiate
-    - QuadraturePoint/Initiate
-    - ElemshapeData/Initiate
-    - MassMatrix
----
-
-# MassMatrix example 2
-
-!!! note ""
-    This example shows how to USE the SUBROUTINE called `MassMatrix` to create a mass matrix in space domain.
-    
-Here, we want to DO the following. 
-
-$$
-\int_{\Omega } N^{I}\rho N^{J}d\Omega
-$$
-
-!!! warning ""
-    `rho` can be a constant, or a FUNCTION of spatial coordinates, or some nonlinear FUNCTION.
-    
-In this example, following mass matrix is formed for [[ReferenceLine_]] element,  [[QuadraturePoint_]] are `GaussLegendre`.
-
-$$
-\int_{\Omega } N^{I} N^{J}d\Omega
-$$
-
-This TYPE of mass matrix is useful in cases WHERE $rho$ is a constant.
-
-## Modules and classes
-
-## Usage
-
-```fortran
 PROGRAM main
-    USE easifemBase
-    IMPLICIT NONE
-    TYPE(Elemshapedata_) :: test, elemsdForsimplex
-    TYPE(Quadraturepoint_) :: quad
-    TYPE(Referenceline_) :: simplexElem, refElem
-    REAL(DFP), ALLOCATABLE :: mat(:, :), XiJ(:, :)
-    INTEGER( I4B ), PARAMETER :: order = 2
-```
+USE easifemBase
 
-!!! note ""
-    Let us now create the physical coordinate of the line element.
+IMPLICIT NONE
 
-```fortran
-    XiJ = RESHAPE([-1, 1], [1, 2])
-```
+TYPE(Elemshapedata_) :: test, elemsdForsimplex
+TYPE(Quadraturepoint_) :: quad
+TYPE(Referenceline_) :: simplexElem, refElem
+REAL(DFP), ALLOCATABLE :: mat(:, :), XiJ(:, :)
+INTEGER(I4B), PARAMETER :: order = 2
 
-!!! note ""
-    Now  we create an instance of [[ReferenceLine_]].
+! Let us now create the physical coordinate of the line element.
+XiJ = RESHAPE([-1, 1], [1, 2])
 
-```fortran
-    simplexElem = referenceline(nsd=1)
-    CALL simplexElem%LagrangeElement(order=order, highOrderObj=refelem)
-```
+! Now  we create an instance of [[ReferenceLine_]].
+simplexElem = referenceline(nsd=1)
+CALL simplexElem%LagrangeElement(order=order, highOrderObj=refelem)
 
-!!! note ""
-    Here, we create the quadrature points.
+! Here, we create the quadrature points.
+CALL initiate(obj=quad, refelem=refelem, order=order * 2, &
+              quadratureType='GaussLegendre')
 
-```fortran
-    CALL initiate( obj=quad, refelem=refelem, order=order*2, &
-        & quadratureType='GaussLegendre' )
-```
+! Initiate an instance of [[ElemshapeData_]]. You can learn more about it from [[ElemshapeData_test]].
+CALL initiate(obj=elemsdForsimplex, &
+              quad=quad, &
+              refelem=simplexElem, &
+              ContinuityType=typeH1, &
+              InterpolType=typeLagrangeInterpolation)
 
-!!! note ""
-    Initiate an instance of [[ElemshapeData_]]. You can learn more about it from [[ElemshapeData_test]].
+! Initiate an instance of [[ElemeshapeData_]].
+CALL initiate(obj=test, &
+              quad=quad, &
+              refelem=refElem, &
+              ContinuityType=typeH1, &
+              InterpolType=typeLagrangeInterpolation)
 
-```fortran
-    CALL initiate(obj=elemsdForsimplex, &
-        & quad=quad, &
-        & refelem=simplexElem, &
-        & ContinuityType=typeH1, &
-        & InterpolType=typeLagrangeInterpolation)
-```
+CALL Set(obj=test, val=xij, N=elemsdForSimplex%N, &
+         dNdXi=elemsdForSimplex%dNdXi)
 
-!!! note ""
-    Initiate an instance of [[ElemeshapeData_]].
-    
-```fortran
-    CALL initiate(obj=test, &
-        & quad=quad, &
-        & refelem=refElem, &
-        & ContinuityType=typeH1, &
-        & InterpolType=typeLagrangeInterpolation)
-    CALL Set(obj=test, val=xij, N=elemsdForSimplex%N, &
-        & dNdXi=elemsdForSimplex%dNdXi)
-```
+! Let us now create the mass matrix.
+mat = MassMatrix(test=test, trial=test)
+CALL Display(mat, "mat:")
 
-!!! note ""
-    Let us now create the mass matrix.
-
-```fortran
-    mat=MassMatrix(test=test, trial=test)
-    CALL Display(mat, "mat:")
-```
-
-??? example "Results"
-
-    ```bash
-                mat:           
-    ---------------------------
-    0.26667  -0.06667  0.13333
-    -0.06667   0.26667  0.13333
-    0.13333   0.13333  1.06667
-    ```
-
-!!! settings "Cleanup"
-
-```fortran
 END PROGRAM main
-```

--- a/docs/docs-api/MassMatrix/examples/_MassMatrix_test_2.md
+++ b/docs/docs-api/MassMatrix/examples/_MassMatrix_test_2.md
@@ -1,31 +1,14 @@
----
-title: MassMatrix example 2
-author: Vikas Sharma, Ph.D.
-date: 20 Nov 2021
-update: 20 Nov 2021 
-tags:
-    - ReferenceLine
-    - ReferenceLine/Initiate
-    - QuadraturePoint/Initiate
-    - ElemshapeData/Initiate
-    - MassMatrix
----
+This example shows how to USE the SUBROUTINE called `MassMatrix` to create a mass matrix in space domain.
 
-# MassMatrix example 2
-
-!!! note ""
-    This example shows how to USE the SUBROUTINE called `MassMatrix` to create a mass matrix in space domain.
-    
-Here, we want to DO the following. 
+Here, we want to DO the following.
 
 $$
 \int_{\Omega } N^{I}\rho N^{J}d\Omega
 $$
 
-!!! warning ""
-    `rho` can be a constant, or a FUNCTION of spatial coordinates, or some nonlinear FUNCTION.
-    
-In this example, following mass matrix is formed for [[ReferenceLine_]] element,  [[QuadraturePoint_]] are `GaussLegendre`.
+`rho` can be a constant, or a FUNCTION of spatial coordinates, or some nonlinear FUNCTION.
+
+In this example, following mass matrix is formed for ReferenceLine element,  QuadraturePoint are `GaussLegendre`.
 
 $$
 \int_{\Omega } N^{I} N^{J}d\Omega
@@ -33,88 +16,3 @@ $$
 
 This TYPE of mass matrix is useful in cases WHERE $rho$ is a constant.
 
-## Modules and classes
-
-## Usage
-
-```fortran
-PROGRAM main
-    USE easifemBase
-    IMPLICIT NONE
-    TYPE(Elemshapedata_) :: test, elemsdForsimplex
-    TYPE(Quadraturepoint_) :: quad
-    TYPE(Referenceline_) :: simplexElem, refElem
-    REAL(DFP), ALLOCATABLE :: mat(:, :), XiJ(:, :)
-    INTEGER( I4B ), PARAMETER :: order = 2
-```
-
-!!! note ""
-    Let us now create the physical coordinate of the line element.
-
-```fortran
-    XiJ = RESHAPE([-1, 1], [1, 2])
-```
-
-!!! note ""
-    Now  we create an instance of [[ReferenceLine_]].
-
-```fortran
-    simplexElem = referenceline(nsd=1)
-    CALL simplexElem%LagrangeElement(order=order, highOrderObj=refelem)
-```
-
-!!! note ""
-    Here, we create the quadrature points.
-
-```fortran
-    CALL initiate( obj=quad, refelem=refelem, order=order*2, &
-        & quadratureType='GaussLegendre' )
-```
-
-!!! note ""
-    Initiate an instance of [[ElemshapeData_]]. You can learn more about it from [[ElemshapeData_test]].
-
-```fortran
-    CALL initiate(obj=elemsdForsimplex, &
-        & quad=quad, &
-        & refelem=simplexElem, &
-        & ContinuityType=typeH1, &
-        & InterpolType=typeLagrangeInterpolation)
-```
-
-!!! note ""
-    Initiate an instance of [[ElemeshapeData_]].
-    
-```fortran
-    CALL initiate(obj=test, &
-        & quad=quad, &
-        & refelem=refElem, &
-        & ContinuityType=typeH1, &
-        & InterpolType=typeLagrangeInterpolation)
-    CALL Set(obj=test, val=xij, N=elemsdForSimplex%N, &
-        & dNdXi=elemsdForSimplex%dNdXi)
-```
-
-!!! note ""
-    Let us now create the mass matrix.
-
-```fortran
-    mat=MassMatrix(test=test, trial=test)
-    CALL Display(mat, "mat:")
-```
-
-??? example "Results"
-
-    ```bash
-                mat:           
-    ---------------------------
-    0.26667  -0.06667  0.13333
-    -0.06667   0.26667  0.13333
-    0.13333   0.13333  1.06667
-    ```
-
-!!! settings "Cleanup"
-
-```fortran
-END PROGRAM main
-```


### PR DESCRIPTION
This pull request focuses on simplifying and improving the readability of documentation and code examples related to the `MassMatrix` functionality. The changes primarily involve the removal of Markdown-style annotations and the restructuring of code comments for better clarity. Additionally, some minor refactoring has been performed in the code examples to enhance consistency.

### Documentation Cleanup and Simplification:
- Removed Markdown-style annotations (e.g., `!!! note`, `!!! warning`) from `docs/docs-api/MassMatrix/examples/MassMatrix_test_3.F90`, `MassMatrix_test_4.F90`, `MassMatrix_test_3.md`, and `MassMatrix_test_4.md`. Comments have been converted to standard Fortran-style comments for better integration with the code. [[1]](diffhunk://#diff-83c6344d95ecf035ed28a7586a6fcff0e9bfd1518fcb9be431b41decf6066c84L1-L40) [[2]](diffhunk://#diff-6c576d334729537956d7859094f189babbf4f0e675e7cd0a19b70496c00fa32dL1-L16) [[3]](diffhunk://#diff-f8f29c4d0de71f0becd9decf164757a4750a1109253893009540f60b80275eb6L1-L40) [[4]](diffhunk://#diff-6f35a5fc94d09af86d35d8fd707dcc661ba559ceb6d7445a8e6b96aecbd68a98L1-L16)

### Code Example Improvements:
- Simplified and standardized comments in `PROGRAM main` for `MassMatrix_test_3.F90` and `MassMatrix_test_4.F90`. Fortran-style comments now replace Markdown annotations, improving readability and consistency. [[1]](diffhunk://#diff-83c6344d95ecf035ed28a7586a6fcff0e9bfd1518fcb9be431b41decf6066c84L49-L133) [[2]](diffhunk://#diff-f8f29c4d0de71f0becd9decf164757a4750a1109253893009540f60b80275eb6L49-L134)
- Adjusted the `MassMatrix` invocation in `_MassMatrix_test_1.F90` and `_MassMatrix_test_2.F90` to ensure consistent naming conventions and parameter usage. Added a `MassMatrix_Method` import in `_MassMatrix_test_1.F90`. [[1]](diffhunk://#diff-5b985c1ce9374d3f88547947d37aa707022cda3c0be661d23deca8db583032b7L7-R7) [[2]](diffhunk://#diff-5b985c1ce9374d3f88547947d37aa707022cda3c0be661d23deca8db583032b7R20-L41) [[3]](diffhunk://#diff-5b985c1ce9374d3f88547947d37aa707022cda3c0be661d23deca8db583032b7L51-R72) [[4]](diffhunk://#diff-012cd9293c5d59e5f4115b539c094d3f5d22ed2bf66801f8996561fe15e87c95L1-L120)

### Mathematical Notation Adjustments:
- Updated references to mathematical elements (e.g., `ReferenceLine_`, `QuadraturePoint_`) to use plain text instead of Markdown-style links for clarity in `MassMatrix_test_3.md` and `MassMatrix_test_4.md`. [[1]](diffhunk://#diff-6c576d334729537956d7859094f189babbf4f0e675e7cd0a19b70496c00fa32dL25-L133) [[2]](diffhunk://#diff-6f35a5fc94d09af86d35d8fd707dcc661ba559ceb6d7445a8e6b96aecbd68a98L25-L134)

These changes collectively improve the documentation and code examples, making them more accessible to developers and users.